### PR TITLE
Fixed errors in settings.json

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -70,7 +70,7 @@
     "window.zoomLevel": 0,
     "workbench.colorTheme": "One Dark Pro",
     "workbench.iconTheme": "material-icon-theme",
-    "terminal.integrated.fontFamily": "Knack Nerd Font, Menlo,DejaVu Sans Mono, Consolas,Lucida Console, monospace"
+    "terminal.integrated.fontFamily": "Knack Nerd Font, Menlo,DejaVu Sans Mono, Consolas,Lucida Console, monospace",
     "terminal.external.osxExec": "Hyper.app",
     "telemetry.enableTelemetry": false,
     "telemetry.enableCrashReporter": false,
@@ -95,7 +95,7 @@
     "git.countBadge": "all",
     "css.validate": true,
     "scss.validate": true,
-    "workbench.iconTheme": "seti",
+//Duplicate    "workbench.iconTheme": "seti",
     "jsAutolint.defaultLinters": ["eslint", "standard"],
     "jsAutolint.enable": true,
     "typescript.check.npmIsInstalled": false


### PR DESCRIPTION
Fixed the **missing comma** on line 73, and commented out **duplicate workbench icon** theme on line 98. 

I commented out the duplicate theme because I'm not sure which one you wanted to keep, material design seemed like the most popular choice on the marketplace.