### PR TITLE
Added dir scaffolding directory functionality

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,14 @@
     - app_store_email is not defined
     - "'app-store' in packages|map(attribute='source')|join(',')"
 
+# Scaffold dirs
+- name: Scaffold package dirs
+  file: path="{{ item.1 }}" state=directory
+  with_subelements:
+    - "{{ packages }}"
+    - scaffold_dirs
+    - skip_missing: yes
+
 # Tap.
 - name: Ensure configured taps are tapped.
   homebrew_tap: 


### PR DESCRIPTION
Added the ability to create folder structures for package entries.

The following example shows how [macstrapped]() would use dir scaffolding to fix azohra/macstrap#5

```yams
packages:
  - name: visual-studio-code
    source: brew-cask
    # extensions: ...
    scaffold_dirs:
      - "~/Library/Application\ Support/Code/User"
    dotfiles: 
      - { src: "{{dotfile_dir}}/settings.json", dest: "~/Library/Application\ Support/Code/User/settings.json" }
```
